### PR TITLE
docs: add SKILL.md template and contribution guide (closes #3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Thanks for considering a contribution to this skills library!
+
+## Adding a new skill
+
+1. **Open an issue** describing the gap and the proposed skill name (kebab-case)
+2. **Wait for a thumbs-up** from a maintainer before opening a PR — this avoids duplicate work and disagreement-after-the-fact
+3. **Create `skills/<skill-name>/SKILL.md`** using the template at [`docs/SKILL_TEMPLATE.md`](docs/SKILL_TEMPLATE.md)
+4. **Update the catalog** table in the root README
+5. **Open a PR** titled `feat(skills): add <skill-name> skill`
+
+## SKILL.md frontmatter
+
+Every SKILL.md begins with YAML frontmatter:
+
+```yaml
+---
+name: <skill-name>
+description: 'One-paragraph behavioral description ending with: Use when: <trigger phrases>.'
+---
+```
+
+The `description` is what AI agents match against when deciding to invoke the skill — make the trigger phrases specific. See [the template](docs/SKILL_TEMPLATE.md) for full guidance.
+
+## Style
+
+- One H1 per file (the skill name)
+- Lead with a `Core Principle` section
+- Tables over long prose where structure exists
+- No external API calls or network dependencies in the skill itself (or, if scaffolded for future wiring, an explicit "not wired" notice)
+- No real customer / company names — use anonymized stand-ins
+- No secrets or PII anywhere
+
+## Quality bar
+
+Before opening a PR, verify against the [quality bar checklist](docs/SKILL_TEMPLATE.md#quality-bar-checklist).
+
+## Compatibility
+
+Skills in this library are intended to work across Claude Code, GitHub Copilot, Cursor, and Codex. The [cross-agent test harness design](docs/CROSS_AGENT_TEST_HARNESS.md) describes how compatibility will be verified once the harness is wired.
+
+## Code of Conduct
+
+We follow the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). Be kind.
+
+## Reporting Issues
+
+For bugs in existing skills: use the bug report template.
+For new skill proposals: use the new skill proposal template.
+For documentation: open an issue with the `docs` label.

--- a/docs/CROSS_AGENT_TEST_HARNESS.md
+++ b/docs/CROSS_AGENT_TEST_HARNESS.md
@@ -1,0 +1,184 @@
+# Cross-Agent Test Harness — Design & Operating Notes
+
+A scaffolding document describing how to verify that skills in this library behave consistently across multiple AI coding agents (Claude Code, GitHub Copilot, Cursor, Codex). Today the verification is manual; this document defines the structure for automating it.
+
+> **No test harness is wired in this commit.** This is a design document, an output schema, and a documented seam. Anyone wiring the actual test runners has a single, well-defined interface to implement per agent.
+
+---
+
+## Why This Matters
+
+Skills in this library claim to be "agent-compatible" — but compatibility is asserted, not tested. A skill that works in Claude Code may silently misbehave in another agent because of differences in:
+
+- How `description` triggers are matched against user intent
+- Token / context window budgets
+- Markdown rendering (table support, frontmatter handling)
+- Tool / file-access primitives the skill assumes are available
+- Streaming vs batch invocation patterns
+
+Without a test harness, regressions reach users before they reach maintainers.
+
+---
+
+## The Three Levels of Compatibility Testing
+
+Different tests answer different questions. The harness supports three distinct levels:
+
+| Level | Tests | Run Frequency | Cost |
+|-------|-------|---------------|------|
+| **L1 — Structural** | SKILL.md frontmatter validity, required sections present, internal links resolve, no banned content | Every PR | Free (no agent invocation) |
+| **L2 — Trigger Match** | Does each agent recognize the skill from its `description` when given the canonical use phrases? | Nightly | Low (one short prompt per agent per skill) |
+| **L3 — Behavioral** | Does the skill produce equivalent (not identical) outputs across agents on a fixed input? | Weekly | High (full skill invocation per agent) |
+
+L1 is the cheapest and catches the most failures. L2 catches "the skill exists but the agent never picks it." L3 catches subtle behavioral drift.
+
+---
+
+## Per-Agent Adapter Interface
+
+Each agent gets one adapter implementing this interface:
+
+```
+class AgentAdapter:
+    name: str             # "claude-code" | "github-copilot" | "cursor" | "codex"
+    available: bool       # whether the adapter has the credentials / runtime to execute
+
+    def install_skills(self, skills_dir: Path) -> None:
+        """Install / register the skills folder with this agent."""
+
+    def trigger_match(self, skill_name: str, prompt: str) -> bool:
+        """L2: given a prompt, did this agent select the named skill?"""
+
+    def invoke(self, prompt: str, timeout_sec: int = 120) -> AgentResponse:
+        """L3: run the agent against a prompt. Return the final response + tool/skill trace."""
+```
+
+If an adapter's `available` is False (missing credentials, runtime not installed), the harness skips that agent's tests with a clear "skipped: <reason>" annotation rather than failing.
+
+---
+
+## Test Definition Schema
+
+Each skill ships an optional `tests.yaml` alongside its SKILL.md:
+
+```yaml
+skill: opportunity-triangulator
+l2_triggers:
+  - "size the opportunity for X"
+  - "what's the TAM for X"
+  - "validate this opportunity"
+  - "is X worth building"
+l3_behavioral:
+  - id: basic-tam-question
+    prompt: "Size the opportunity for an AI-native CRM for solo lawyers."
+    expectations:
+      - structure: "must contain 3 named sizing methods"
+      - structure: "must contain a gap-analysis section"
+      - quality: "TAM number must be present and within 1 order of magnitude across agents"
+      - quality: "all three methods must produce numbers within 2x of each other"
+```
+
+`structure` expectations are evaluated with simple regex / section-presence checks. `quality` expectations are evaluated by a judge model against a rubric (see L3 Scoring below).
+
+---
+
+## L1 — Structural Validation
+
+Runs on every PR. Pure static analysis, zero agent invocations:
+
+| Check | Failure Action |
+|-------|----------------|
+| `name` field in frontmatter is present and matches folder name | Block PR |
+| `description` field is present, non-empty, ≤ 500 chars | Block PR |
+| `description` contains a `Use when:` clause with ≥ 3 trigger phrases | Warn |
+| All internal markdown links resolve | Block PR |
+| No external dependencies named without an explicit "no-wiring" notice | Warn |
+| File size < 50 KB (large skills are usually under-decomposed) | Warn |
+
+L1 is implemented in CI (GitHub Actions); no agent runtime needed.
+
+---
+
+## L2 — Trigger Match Testing
+
+For each skill's `l2_triggers`, run each adapter:
+
+1. Install the skill into the agent's skills directory
+2. Issue the trigger prompt as a fresh conversation
+3. Inspect: did the agent select the named skill?
+4. Record pass/fail per (agent × trigger × skill)
+
+Output: a per-skill trigger-match matrix that surfaces "this skill works in Claude Code but never gets picked by Cursor" patterns.
+
+---
+
+## L3 — Behavioral Equivalence Testing
+
+The hardest level. Runs the full skill end-to-end on each agent and checks that outputs are *equivalent*, not *identical* (model differences make identical impossible).
+
+### Equivalence Criteria
+
+| Type | Definition |
+|------|------------|
+| **Structural** | Required sections present, output format matches, key fields populated |
+| **Quantitative** | Numbers within tolerance (e.g., TAM estimates within 1 order of magnitude) |
+| **Qualitative** | Judge-model rubric scores within 1 point on a 0–3 scale |
+
+### L3 Scoring with a Judge Model
+
+For qualitative checks, a judge model (separate from the agents under test) scores each agent's output against the skill's expected-behavior rubric. The judge model is *the same* across all agents to keep scoring fair.
+
+**Important:** the judge model is not wired in this scaffolding. The seam exists; the implementation is deferred until the broader test harness is built.
+
+---
+
+## Output
+
+The harness produces a **Compatibility Report** per release:
+
+```
+## ai-skills-library — Compatibility Report (release v1.4.0)
+
+| Skill                       | L1 | L2 (CC) | L2 (GHC) | L2 (Cursor) | L3 (CC) | L3 (GHC) | L3 (Cursor) |
+|-----------------------------|----|---------|----------|-------------|---------|----------|-------------|
+| opportunity-triangulator    | ✅ | ✅ 4/4  | ✅ 4/4   | ⚠️ 3/4      | ✅      | ✅       | ⚠️          |
+| jtbd-extractor              | ✅ | ✅ 5/5  | ✅ 5/5   | ✅ 5/5      | ✅      | ✅       | ✅          |
+```
+
+Skills with L2/L3 failures are flagged for skill-author attention before release. Skills that pass all levels can carry an `"Agent-Compatible: Verified"` badge.
+
+---
+
+## Cost Considerations
+
+The harness is opt-in by level:
+
+- **L1 only** (default in CI) — free, runs every PR
+- **L1 + L2** — small cost per skill per agent per night
+- **L1 + L2 + L3** — moderate cost; recommended weekly only
+
+Expected per-run cost is bounded by:
+- Number of skills × number of agents × number of test cases per skill
+- Each test case is 1 prompt + 1 response (L2) or 1 full skill invocation (L3)
+
+For a library of 12 skills × 4 agents × 5 cases per skill, L3 weekly = 240 invocations/week. The harness ships a `--max-cost-usd` flag that caps total spend per run.
+
+---
+
+## Out of Scope (for this scaffolding)
+
+- Wiring any specific agent adapter
+- Implementing the judge model
+- CI integration (GitHub Actions workflow files)
+- Cost reporting integration
+- Compatibility badge automation
+
+These are tracked as follow-on work; the design above is stable and the seams above are sufficient to start implementation.
+
+---
+
+## Why This Is Scaffolding, Not Implementation
+
+Wiring real agents requires either bundling per-agent runtimes (Claude Code, Copilot CLI, Cursor extension APIs, etc.) or running them headlessly via specific subprocess / CLI integrations that vary substantially between agents. That work is meaningful but is a separate effort from defining *what* the harness should test and *how* its outputs should be structured.
+
+This document captures the latter so the wiring work — when it happens — has clear targets.

--- a/docs/SKILL_TEMPLATE.md
+++ b/docs/SKILL_TEMPLATE.md
@@ -1,0 +1,146 @@
+# SKILL.md Template
+
+Copy this template when authoring a new skill. Replace placeholders in `<angle brackets>` and delete sections that don't apply, but preserve the section *order* — it's what readers (and AI agents matching descriptions) expect.
+
+```markdown
+---
+name: <skill-name-in-kebab-case>
+description: '<One paragraph describing what the skill does. End with: Use when: <trigger phrase 1>, <trigger phrase 2>, <trigger phrase 3>.>'
+---
+
+# <Skill Display Name>
+
+<Two-sentence elevator pitch: what this skill does and why it exists. The reader should be able to decide in 10 seconds whether to invoke this skill or a different one.>
+
+## Core Principle
+
+**<The single key insight that the skill embodies, bolded.>** <One paragraph elaborating why this principle matters and what failures it prevents.>
+
+## What You'll Get
+
+| Artifact | Description |
+|----------|-------------|
+| **<Output 1>** | <One-sentence description> |
+| **<Output 2>** | <One-sentence description> |
+| **<Output 3>** | <One-sentence description> |
+
+## Output
+
+Save to `outputs/<topic>-[name]-[YYYY-MM-DD].md`
+
+## Process
+
+### Step 1: <Intake / Frame the Problem>
+I'll ask:
+> "<The 1–2 questions that frame the skill's input.>"
+
+### Step 2: <Core Step>
+<What the skill does mechanically. Be specific.>
+
+### Step 3: <Synthesize / Output>
+<How outputs are produced and structured.>
+
+## Demo Scenario (optional)
+
+**Input:**
+> <A realistic prompt the skill could receive.>
+
+**Sample Output (excerpt):**
+
+| <Column 1> | <Column 2> | <Column 3> |
+|------------|------------|------------|
+| ... | ... | ... |
+
+## Tips
+1. **<Tip headline>.** <One-sentence elaboration.>
+2. **<Tip headline>.** <One-sentence elaboration.>
+3. **<Tip headline>.** <One-sentence elaboration.>
+
+## Pairs With (optional)
+- **<other-skill>** — <how they compose>
+```
+
+---
+
+## Authoring Conventions
+
+These are the rules that make a skill *good*, not just complete.
+
+### Frontmatter
+
+| Field | Required? | Notes |
+|-------|-----------|-------|
+| `name` | Yes | Must match the folder name (kebab-case) |
+| `description` | Yes | Two parts: the *what* (one paragraph) + the *Use when* trigger list |
+| Other fields | No | Don't add them — they confuse compatibility across agents |
+
+The `Use when:` clause matters more than the description body. AI agents match user intent against trigger phrases; ambiguous triggers mean the skill never gets selected.
+
+### Tone
+
+- Direct and decision-oriented
+- No hedging filler ("may potentially possibly")
+- Tables over long prose where structure exists
+- Quantitative where possible
+
+### Section Order (don't reorder)
+
+1. **Core Principle** — the insight
+2. **What You'll Get / Output** — the deliverable
+3. **Process** — how the skill operates
+4. **Demo Scenario** (optional) — concrete example
+5. **Tips** — operating wisdom
+6. **Pairs With** (optional) — composition with other skills
+
+### Length Guidelines
+
+| Skill complexity | Target length |
+|------------------|---------------|
+| Simple (single output, single framework) | 1.5–3 KB |
+| Standard (multi-step process, scoring rubric) | 3–6 KB |
+| Complex (multiple sub-frameworks, demos) | 6–10 KB |
+| Larger | Almost always means the skill should be split into 2 |
+
+If you're over 10 KB, decompose: each major sub-framework becomes its own skill, with a "pairs with" link.
+
+---
+
+## Quality Bar Checklist
+
+Before opening a PR for a new skill, verify:
+
+- [ ] `name` matches folder name (kebab-case)
+- [ ] `description` ends with a `Use when:` clause containing ≥ 3 trigger phrases
+- [ ] Core Principle is a single bolded sentence followed by one paragraph
+- [ ] Process has at least 3 numbered steps
+- [ ] Output location is specified (`outputs/<topic>-...md`)
+- [ ] At least 3 Tips, each with a bolded headline
+- [ ] No external API dependencies (or, if scaffolded for future wiring, an explicit "not wired" notice)
+- [ ] No real customer / company names in examples — use anonymized stand-ins
+- [ ] No PII or secrets anywhere in the file
+- [ ] Total length is appropriate (see Length Guidelines above)
+
+---
+
+## Common Mistakes to Avoid
+
+| Mistake | Fix |
+|---------|-----|
+| `description` reads like a tagline ("the best X tool!") | Replace with a behavioral description: what the skill *does*, not what it *is* |
+| `Use when:` triggers are vague ("when needed") | Concrete phrases the user might actually type |
+| One H1 per file is violated | Exactly one H1 (the skill name); use H2 / H3 for everything else |
+| Process steps lack a clear "I'll ask" intake | Skills without intake feel impersonal; explicit intake builds trust |
+| Tips are generic platitudes | Tips should be the *operating wisdom* — what someone learns running this skill 50 times |
+| Demo uses real customer names | Always anonymize ("[Customer X], 1,200 FTEs in your industry") |
+| Skill claims to "integrate with X" without wiring | Either wire it, or explicitly mark as "scaffolded, not wired" with a path to live mode |
+
+---
+
+## Submitting a New Skill
+
+1. Open an issue describing the gap and the proposed skill name (kebab-case)
+2. Wait for thumbs-up from a maintainer
+3. Create `skills/<skill-name>/SKILL.md` from the template above
+4. Optionally add `examples/` and `tests.yaml`
+5. Update the catalog table in the root README
+6. Open a PR titled `feat(skills): add <skill-name> skill`


### PR DESCRIPTION
Adds docs/SKILL_TEMPLATE.md with the full SKILL.md template, authoring conventions, length guidelines, quality bar checklist, and common mistakes to avoid. Adds CONTRIBUTING.md as the entry point that points at the template. Establishes the consistent pattern for new skill submissions.