### PR TITLE
docs+license: extend copyright to 2025-2026 and surface document-processing in subtitle

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Varun Kulkarni
+Copyright (c) 2025-2026 Varun Kulkarni
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧰 Claude Code Custom Skills
 
-### A curated, categorized library of production-grade skills for Claude Code — finance, product, strategy, and game theory.
+### A curated, categorized library of production-grade skills for Claude Code — finance, product, strategy, game theory, and document processing.
 
 [![Custom Skills](https://img.shields.io/badge/Custom_Skills-29-blue?style=for-the-badge)](#-skill-categories)
 [![Categories](https://img.shields.io/badge/Categories-5-orange?style=for-the-badge)](#-skill-categories)


### PR DESCRIPTION
## Summary

1. LICENSE copyright was 2025 only — extend to 2025-2026.
2. The README subtitle listed four of the five skill categories (*"finance, product, strategy, and game theory"*) but omitted **document processing**, even though it has its own folder, README, and skill (`pdf-processing`), and the GitHub repo description includes it. Add for parity.

## Changes (2 commits)

1. `chore(license): extend copyright range to 2025-2026`
2. `docs(readme): add 'document processing' to subtitle category list`